### PR TITLE
handle the expiration timezone of tokens

### DIFF
--- a/keystoneauth_websso/plugin.py
+++ b/keystoneauth_websso/plugin.py
@@ -20,7 +20,7 @@ import os
 import re
 import socket
 import webbrowser
-from datetime import datetime
+from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
 import multipart
@@ -318,9 +318,9 @@ class OpenIDConnect(federation.FederationBaseAuth):
         _data = json.loads(data)
 
         expiration = datetime.strptime(
-            _data["body"]["token"]["expires_at"], "%Y-%m-%dT%H:%M:%S.%fZ"
+            _data["body"]["token"]["expires_at"], "%Y-%m-%dT%H:%M:%S.%f%z"
         )
-        now = datetime.now()
+        now = datetime.now(timezone.utc)
         if expiration < now:
             return True
         else:


### PR DESCRIPTION
The code was parsing the time as timezone naive and then getting the local time and comparing it. However keystone returns the expiration as UTC and anchored with the Z so we should parse it as timezone aware and then compare it as timezone aware.